### PR TITLE
Break down `Rib.Simple` into reusable functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ This will:
 - Drop into a nix-shell with needed Haskell dependencies
 - Compile the `rib` library and `example/Main.hs` through ghcid
   - Whenever Haskell sources change ghcid reloads them
-- Run `example/Main.hs:main` with `serve -w` CLI arguments
+- Run `example/Main.hs:buildAction` (as if with `serve -w` CLI arguments)
 - This does the following:
   1. Convert sources in `./example/a` into `./example/b` using Shake
   2. Listens for changes to `./example/a`, and re-generate them (i.e., the `-w` argument)

--- a/doc/Main.hs
+++ b/doc/Main.hs
@@ -27,6 +27,7 @@ import qualified Rib.App as App
 import Rib.Pandoc (getPandocMetaHTML, getPandocMetaValue, highlightingCss, pandoc2Html, parsePandoc,
                    setPandocMetaValue)
 import Rib.Server (getHTMLFileUrl)
+import qualified Rib.Shake as Shake
 import Rib.Simple (Page (..))
 import qualified Rib.Simple as Simple
 
@@ -35,15 +36,15 @@ main = App.run buildAction
 
 buildAction :: Action ()
 buildAction = do
-  void $ Simple.buildStaticFiles ["static//**"]
+  void $ Shake.buildStaticFiles ["static//**"]
 
   toc <- guideToc
-  posts <- applyGuide toc <$> Simple.readPandocMulti ["*.md"]
+  posts <- applyGuide toc <$> Shake.readPandocMulti ["*.md"]
 
   void $ forP posts $ \x ->
-    Simple.buildHtml (fst x -<.> "html") (renderPage $ Page_Post x)
+    Shake.buildHtml (fst x -<.> "html") (renderPage $ Page_Post x)
 
-  Simple.buildHtml "index.html" $ renderPage $ Page_Index posts
+  Shake.buildHtml "index.html" $ renderPage $ Page_Index posts
 
 -- | Apply the guide metadata to a list of pages
 -- TODO: refactor

--- a/doc/Main.hs
+++ b/doc/Main.hs
@@ -47,7 +47,6 @@ buildAction = do
   Shake.buildHtml "index.html" $ renderPage $ Page_Index posts
 
 -- | Apply the guide metadata to a list of pages
--- TODO: refactor
 applyGuide :: (Ord f, Show f) => [f] -> [(f, Pandoc)] -> [(f, Pandoc)]
 applyGuide fs xs =
   flip mapWithAdj fsComplete $ \mprev (f, doc) mnext -> (f,) $

--- a/doc/a/inbox.md
+++ b/doc/a/inbox.md
@@ -16,13 +16,11 @@ description: This stuff is hidden if not private
 
 - [X] MVP - rib.srid.ca
 - [ ] Navigation (next <> title <> prev)
-  - Define post slugs (/inbox.md => "/inbox.md")
-    - Make a `map` of posts keyed by their slug
-    - Have getPageUrl use this
-  - Define hierarchy in Main.hs:
-    ```
-    postHierarchy = [ "/introduction", "/getting-started" ]
-    ```
+  - [X] Post slugs and `guide.json`
+  - [ ] Pandoc metadata system (at least, as simple as `setPandocMetaValue`)
+  - [ ] Inject next/prev keys into Pandoc metadata
+    - [ ] Patch `DocPage` in the render function passed to `buildHtmlMulti`
+      - Need to do a lookup guide.json each time, which is okay.
 
 
 ### Rib, for journaling

--- a/doc/a/inbox.md
+++ b/doc/a/inbox.md
@@ -17,10 +17,11 @@ description: This stuff is hidden if not private
 - [X] MVP - rib.srid.ca
 - [ ] Navigation (next <> title <> prev)
   - [X] Post slugs and `guide.json`
-  - [ ] Pandoc metadata system (at least, as simple as `setPandocMetaValue`)
+  - [X] Pandoc metadata system (at least, as simple as `setPandocMetaValue`)
   - [ ] Inject next/prev keys into Pandoc metadata
-    - [ ] Patch `DocPage` in the render function passed to `buildHtmlMulti`
+    - [X] Patch `DocPage` in the render function passed to `buildHtmlMulti`
       - Need to do a lookup guide.json each time, which is okay.
+    - [ ] Include title from yet-unparsed next/prev docs. How? :-S
 
 
 ### Rib, for journaling

--- a/doc/a/inbox.md
+++ b/doc/a/inbox.md
@@ -21,7 +21,10 @@ description: This stuff is hidden if not private
   - [ ] Inject next/prev keys into Pandoc metadata
     - [X] Patch `DocPage` in the render function passed to `buildHtmlMulti`
       - Need to do a lookup guide.json each time, which is okay.
-    - [ ] Include title from yet-unparsed next/prev docs. How? :-S
+    - [X] Include title from yet-unparsed next/prev docs. How? :-S
+      - [ ] Refactor
+- [ ] getting-started: instruct cp example/Main.hs and create a separate page
+      explaining Main.hs (literate haskell if possible;)
 
 
 ### Rib, for journaling

--- a/example/Main.hs
+++ b/example/Main.hs
@@ -13,7 +13,7 @@ import Lucid
 import qualified Rib.App as App
 import Rib.Pandoc (getPandocMetaHTML, highlightingCss, pandoc2Html)
 import Rib.Server (getHTMLFileUrl)
-import Rib.Simple (Page (..), Post (..), isDraft)
+import Rib.Simple (Page (..), isDraft)
 import qualified Rib.Simple as Simple
 
 main :: IO ()
@@ -35,21 +35,21 @@ renderPage page = with html_ [lang_ "en"] $ do
       h1_ pageTitle
       case page of
         Page_Index posts ->
-          div_ $ forM_ posts $ \post -> div_ $ do
-            with a_ [href_ (getHTMLFileUrl $ _post_srcPath post)] $ postTitle post
-            small_ $ maybe mempty toHtmlRaw $ getPandocMetaHTML "description" $ _post_doc post
-        Page_Post post -> do
-          when (isDraft post) $
+          div_ $ forM_ posts $ \(f, doc) -> div_ $ do
+            with a_ [href_ (getHTMLFileUrl f)] $ postTitle doc
+            small_ $ maybe mempty toHtmlRaw $ getPandocMetaHTML "description" doc
+        Page_Post (_, doc) -> do
+          when (isDraft doc) $
             div_ "This is a draft"
           with article_ [class_ "post"] $
-            toHtmlRaw $ pandoc2Html $ _post_doc post
+            toHtmlRaw $ pandoc2Html doc
   where
     pageTitle = case page of
       Page_Index _ -> "My website!"
-      Page_Post post -> postTitle post
+      Page_Post (_, doc) -> postTitle doc
 
     -- Render the post title (Markdown supported)
-    postTitle = maybe "Untitled" toHtmlRaw . getPandocMetaHTML "title" . _post_doc
+    postTitle = maybe "Untitled" toHtmlRaw . getPandocMetaHTML "title"
 
     -- | CSS
     pageStyle :: Css

--- a/src/Rib/Pandoc.hs
+++ b/src/Rib/Pandoc.hs
@@ -6,6 +6,7 @@ module Rib.Pandoc where
 import Data.Maybe
 import Data.Text (Text)
 import qualified Data.Text as T
+import qualified Data.Map as Map
 import Text.Read (readMaybe)
 
 import Lucid (Html, toHtmlRaw)
@@ -46,6 +47,21 @@ getPandocMetaValue k doc = do
 -- | Get the YAML metadata, parsing it to Pandoc doc and then to HTML
 getPandocMetaHTML :: String -> Pandoc -> Maybe (Html ())
 getPandocMetaHTML k = fmap pandocInlines2Html . getPandocMetaInlines k
+
+-- | Add, or set, a metadata data key to the given Haskell value
+setPandocMetaValue :: Show a => String -> a -> Pandoc -> Pandoc
+setPandocMetaValue k v (Pandoc (Meta meta) bs) = Pandoc (Meta meta') bs
+  where
+    meta' = Map.insert k v' meta
+    v' = MetaInlines [Str $ show v]
+
+data PostMeta = PostMeta
+  { _postMeta_title :: Maybe [Inline]
+  , _postMeta_draft :: Maybe Bool
+  , _postMeta_next :: Maybe FilePath
+  }
+-- TODO: can I use dependent map here?
+-- getPandocMeta :: Pandoc -> [(String, DSum a Identity)] -> DMap a Identity
 
 pandoc2Html' :: Pandoc -> Either PandocError Text
 pandoc2Html' = runPure . writeHtml5String settings

--- a/src/Rib/Pandoc.hs
+++ b/src/Rib/Pandoc.hs
@@ -55,14 +55,6 @@ setPandocMetaValue k v (Pandoc (Meta meta) bs) = Pandoc (Meta meta') bs
     meta' = Map.insert k v' meta
     v' = MetaInlines [Str $ show v]
 
-data PostMeta = PostMeta
-  { _postMeta_title :: Maybe [Inline]
-  , _postMeta_draft :: Maybe Bool
-  , _postMeta_next :: Maybe FilePath
-  }
--- TODO: can I use dependent map here?
--- getPandocMeta :: Pandoc -> [(String, DSum a Identity)] -> DMap a Identity
-
 pandoc2Html' :: Pandoc -> Either PandocError Text
 pandoc2Html' = runPure . writeHtml5String settings
   where

--- a/src/Rib/Pandoc.hs
+++ b/src/Rib/Pandoc.hs
@@ -3,10 +3,10 @@
 -- | Helpers for working with Pandoc documents
 module Rib.Pandoc where
 
+import qualified Data.Map as Map
 import Data.Maybe
 import Data.Text (Text)
 import qualified Data.Text as T
-import qualified Data.Map as Map
 import Text.Read (readMaybe)
 
 import Lucid (Html, toHtmlRaw)

--- a/src/Rib/Shake.hs
+++ b/src/Rib/Shake.hs
@@ -39,9 +39,6 @@ buildStaticFiles staticFilePatterns = do
 -- Call `mkA` to create the final value given a file and its pandoc structure.
 -- Return the list of final values used to render their HTMLs.
 buildHtmlMulti
-  -- :: (ToJSON a, FromJSON a)
-  -- => (FilePath -> Pandoc -> a)
-  -- ^ TODO: Just deal with `(FilePath, Pandoc)` instead of some `a`
   :: [FilePattern]
   -- ^ Source file patterns
   -> ((FilePath, Pandoc) -> Html ())

--- a/src/Rib/Shake.hs
+++ b/src/Rib/Shake.hs
@@ -1,37 +1,77 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TupleSections #-}
 
-module Rib.Shake
-  ( ribShake
-  , jsonCacheAction
-  , Action
-  ) where
+-- | Combinators for working with Shake
+module Rib.Shake where
 
+import Control.Monad
+import Control.Monad.IO.Class
 import Data.Aeson (FromJSON, ToJSON)
 import qualified Data.Aeson as Aeson
 import Data.Binary
-import Data.Bool (bool)
+import qualified Data.ByteString.Char8 as BSC
+import qualified Data.Text.Encoding as T
+import qualified Data.Text.Encoding.Error as T
 import Data.Typeable
 
 import Development.Shake
-import Development.Shake.Forward (cacheAction, shakeForward)
+import Development.Shake.FilePath
+import Development.Shake.Forward (cacheAction)
+import Lucid
+import Text.Pandoc (Pandoc)
+
+import Rib.App (ribInputDir, ribOutputDir)
+import Rib.Pandoc (parsePandoc)
 
 
--- TODO: Should we get rid of this, and have the user directly call shakeForward?
--- As this way we can get rid of the "framework" feel in Main.hs
-ribShake
-  :: Bool
-  -- ^ Force generate of requested targets
-  -> Action ()
-  -- ^ Site build action
-  -> IO ()
-ribShake forceGen buildAction = do
-  let opts = shakeOptions
-        { shakeVerbosity = Chatty
-        , shakeRebuild = bool [] [(RebuildNow, "**")] forceGen
-        }
-  shakeForward opts buildAction
+-- | Shake action to copy static files as is
+buildStaticFiles :: [FilePattern] -> Action [FilePath]
+buildStaticFiles staticFilePatterns = do
+  files <- getDirectoryFiles ribInputDir staticFilePatterns
+  void $ forP files $ \f ->
+    copyFileChanged (ribInputDir </> f) (ribOutputDir </> f)
+  pure files
+
+-- | Build multiple HTML files given a pattern of source files
+--
+-- Call `mkA` to create the final value given a file and its pandoc structure.
+-- Return the list of final values used to render their HTMLs.
+buildHtmlMulti
+  -- :: (ToJSON a, FromJSON a)
+  -- => (FilePath -> Pandoc -> a)
+  -- ^ TODO: Just deal with `(FilePath, Pandoc)` instead of some `a`
+  :: [FilePattern]
+  -- ^ Source file patterns
+  -> ((FilePath, Pandoc) -> Html ())
+  -> Action [(FilePath, Pandoc)]
+buildHtmlMulti pat r = do
+  xs <- readPandocMulti pat
+  void $ forP xs $ \x ->
+    buildHtml (fst x -<.> "html") (r x)
+  pure xs
+
+readPandocMulti :: [FilePattern] -> Action [(FilePath, Pandoc)]
+readPandocMulti pat = do
+  fs <- getDirectoryFiles ribInputDir pat
+  forP fs $ \f ->
+    jsonCacheAction f $ (f, ) <$> readPandoc f
+
+readPandoc :: FilePath -> Action Pandoc
+readPandoc =
+    fmap (parsePandoc . T.decodeUtf8With T.lenientDecode . BSC.pack)
+  . readFile'
+  . (ribInputDir </>)
+
+-- | Build a single HTML file with the given value
+buildHtml :: FilePath -> Html () -> Action ()
+buildHtml f html = do
+  let out = ribOutputDir </> f
+  writeHtml out html
+
+writeHtml :: MonadIO m => FilePath -> Html () -> m ()
+writeHtml f = liftIO . renderToFile f
 
 -- | Like `Development.Shake.cacheAction` but uses JSON instance instead of Typeable / Binary on `b`.
 jsonCacheAction :: (FromJSON b, Typeable k, Binary k, Show k, ToJSON a) => k -> Action a -> Action b

--- a/src/Rib/Simple.hs
+++ b/src/Rib/Simple.hs
@@ -44,6 +44,8 @@ buildAction renderPage = do
   buildHtml "index.html" $  renderPage $ Page_Index publicPosts
 
 -- XXX: everything below is independent of Page type. yay!
+-- TODO: Move to `Rib.Shake`?
+-- TODO: And get rid of the above, and have Main.hs do it manually.
 
 -- | Shake action to copy static files as is
 buildStaticFiles :: [FilePattern] -> Action [FilePath]

--- a/src/Rib/Simple.hs
+++ b/src/Rib/Simple.hs
@@ -32,6 +32,7 @@ data Page
   | Page_Post (FilePath, Pandoc)
   deriving (Generic, Show, FromJSON, ToJSON)
 
+-- TODO: Eventually this should be subsumed into our Pandoc metadata system.
 isDraft :: Pandoc -> Bool
 isDraft = fromMaybe False . getPandocMetaValue "draft"
 

--- a/src/Rib/Simple.hs
+++ b/src/Rib/Simple.hs
@@ -34,5 +34,3 @@ buildAction renderPage = do
   posts <- buildHtmlMulti ["*.md"] $ renderPage . Page_Post
   let publicPosts = filter (not . isDraft . snd) posts
   buildHtml "index.html" $  renderPage $ Page_Index publicPosts
-
--- TODO: Get get rid of the above, and have Main.hs do it manually.

--- a/src/Rib/Simple.hs
+++ b/src/Rib/Simple.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TupleSections #-}
 

--- a/src/Rib/Simple.hs
+++ b/src/Rib/Simple.hs
@@ -2,28 +2,21 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TupleSections #-}
 
 -- Sensible defaults for writing the most simple static site
 module Rib.Simple where
 
 import Control.Monad
-import Control.Monad.IO.Class
 import Data.Aeson (FromJSON, ToJSON)
-import qualified Data.ByteString.Char8 as BSC
 import Data.Maybe
-import qualified Data.Text.Encoding as T
-import qualified Data.Text.Encoding.Error as T
 import GHC.Generics (Generic)
 
 import Development.Shake
-import Development.Shake.FilePath
 import Lucid
 import Text.Pandoc (Pandoc)
 
-import Rib.App (ribInputDir, ribOutputDir)
-import Rib.Pandoc (getPandocMetaValue, parsePandoc)
-import Rib.Shake (Action, jsonCacheAction)
+import Rib.Pandoc (getPandocMetaValue)
+import Rib.Shake
 
 -- | An HTML page that will be generated
 data Page
@@ -42,53 +35,4 @@ buildAction renderPage = do
   let publicPosts = filter (not . isDraft . snd) posts
   buildHtml "index.html" $  renderPage $ Page_Index publicPosts
 
--- XXX: everything below is independent of Page type. yay!
--- TODO: Move to `Rib.Shake`?
--- TODO: And get rid of the above, and have Main.hs do it manually.
-
--- | Shake action to copy static files as is
-buildStaticFiles :: [FilePattern] -> Action [FilePath]
-buildStaticFiles staticFilePatterns = do
-  files <- getDirectoryFiles ribInputDir staticFilePatterns
-  void $ forP files $ \f ->
-    copyFileChanged (ribInputDir </> f) (ribOutputDir </> f)
-  pure files
-
--- | Build multiple HTML files given a pattern of source files
---
--- Call `mkA` to create the final value given a file and its pandoc structure.
--- Return the list of final values used to render their HTMLs.
-buildHtmlMulti
-  -- :: (ToJSON a, FromJSON a)
-  -- => (FilePath -> Pandoc -> a)
-  -- ^ TODO: Just deal with `(FilePath, Pandoc)` instead of some `a`
-  :: [FilePattern]
-  -- ^ Source file patterns
-  -> ((FilePath, Pandoc) -> Html ())
-  -> Action [(FilePath, Pandoc)]
-buildHtmlMulti pat r = do
-  xs <- readPandocMulti pat
-  void $ forP xs $ \x ->
-    buildHtml (fst x -<.> "html") (r x)
-  pure xs
-
-readPandocMulti :: [FilePattern] -> Action [(FilePath, Pandoc)]
-readPandocMulti pat = do
-  fs <- getDirectoryFiles ribInputDir pat
-  forP fs $ \f ->
-    jsonCacheAction f $ (f, ) <$> readPandoc f
-
-readPandoc :: FilePath -> Action Pandoc
-readPandoc =
-    fmap (parsePandoc . T.decodeUtf8With T.lenientDecode . BSC.pack)
-  . readFile'
-  . (ribInputDir </>)
-
--- | Build a single HTML file with the given value
-buildHtml :: FilePath -> Html () -> Action ()
-buildHtml f html = do
-  let out = ribOutputDir </> f
-  writeHtml out html
-
-writeHtml :: MonadIO m => FilePath -> Html () -> m ()
-writeHtml f = liftIO . renderToFile f
+-- TODO: Get get rid of the above, and have Main.hs do it manually.


### PR DESCRIPTION
Needed to customize the page objects in the docs site before they get written to disk.