### PR TITLE
Configurable input output directories

### DIFF
--- a/rib.cabal
+++ b/rib.cabal
@@ -60,4 +60,5 @@ library
         wai-extra >=3.0.26 && <3.1,
         warp >=3.2.28 && <3.3,
         base >=4.7 && <5,
-        pandoc >=2.7 && <3
+        pandoc >=2.7 && <3,
+        directory >= 1.0 && <2.0


### PR DESCRIPTION
Hi @srid, 

I really like rib and I'm trying to move my blog to it.  This draft PR is an attempt to address #33 There's still work with it, but I'd like to have your opinion if you think this goes in the right direction.

* I'm using `shakeExtra` to store the input and output directories.  These values are accessible from Actions using `getShakeExtra`. In `Rib.Shake` I converted ribInputDir and ribOutputDir into an `Action`
* `ribOutputDir` is now created if it doesn't exist
* The input and output directories, still hard-coded, are set in `runWith` of `Rib/App.hs`.

I'm considering adding the input and output directories to the `App` structure. Do you think it's a good idea?

I'd appreciate your feedback!

Thanks.

Closes #33 


