### PR TITLE
Implement shake caching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Fix #63: create intermediate directories when generating post HTML
 - Advance nixpkgs; require Shake >=0.18.4
 - Fix unnecessary rebuild of all files when only one file changed
+  - Use caching, to avoid writing HTML to disk until it has changed.
 
 ## 0.5.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 - Fix #63: create intermediate directories when generating post HTML
 - Advance nixpkgs; require Shake >=0.18.4
 - Fix unnecessary rebuild of all files when only one file changed
-  - Use caching, to avoid writing HTML to disk until it has changed.
+  - Use caching (via Shake's `cacheActionWith`), to avoid writing HTML to disk until it has changed.
 
 ## 0.5.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - API: Expose `ribInputDir` and `ribOutputDir` for use in custom Shake actions
 - Fix #63: create intermediate directories when generating post HTML
 - Advance nixpkgs; require Shake >=0.18.4
+- Fix unnecessary rebuild of all files when only one file changed
 
 ## 0.5.0.0
 

--- a/default.nix
+++ b/default.nix
@@ -76,6 +76,7 @@ haskellPackages.developPackage {
         (t.flip h.addBuildTools) (with haskellPackages;
           [ cabal-install
             ghcid
+            pkgs.fsatrace  # Used by Shake.Development.Forward
           ]);
     in (t.flip t.pipe) [
       addExtraDeps

--- a/rib.cabal
+++ b/rib.cabal
@@ -64,6 +64,7 @@ library
         relude >= 0.6 && < 0.7,
         shake >= 0.18.4,
         text >=1.2.3 && <1.3,
+        uuid,
         wai >=3.2.2 && <3.3,
         wai-app-static >=3.1.6 && <3.2,
         warp

--- a/rib.cabal
+++ b/rib.cabal
@@ -64,7 +64,6 @@ library
         relude >= 0.6 && < 0.7,
         shake >= 0.18.4,
         text >=1.2.3 && <1.3,
-        uuid,
         wai >=3.2.2 && <3.3,
         wai-app-static >=3.1.6 && <3.2,
         warp

--- a/src/Rib/App.hs
+++ b/src/Rib/App.hs
@@ -95,8 +95,8 @@ runWith src dst buildAction = \case
   Generate fullGen ->
     flip shakeForward buildAction $
       shakeOptions
-        { shakeVerbosity = Chatty,
+        { shakeVerbosity = Verbose,
           shakeRebuild = bool [] [(RebuildNow, "**")] fullGen,
-          shakeLintInside = [toFilePath src, toFilePath dst],
+          shakeLintInside = [""],
           shakeExtra = addShakeExtra (Dirs (src, dst)) (shakeExtra shakeOptions)
         }

--- a/src/Rib/App.hs
+++ b/src/Rib/App.hs
@@ -82,6 +82,10 @@ runWith src dst buildAction = \case
   WatchAndGenerate -> withManager $ \mgr -> do
     uuid <- UUID.nextRandom
     -- Begin with a *full* generation as the HTML layout may have been changed.
+    -- TODO: This assumption is not true when running the program from compiled
+    -- binary (as opposed to say via ghcid) as the HTML layout has become fixed
+    -- by being part of the binary. In this scenario, we should not do full
+    -- generation (i.e., toggle the bool here to False).
     runShake uuid True
     -- And then every time a file changes under the current directory
     putStrLn $ "[Rib] Watching " <> toFilePath src

--- a/src/Rib/App.hs
+++ b/src/Rib/App.hs
@@ -86,7 +86,7 @@ runWith src dst buildAction = \case
     -- generation (i.e., toggle the bool here to False).
     runShake True
     -- And then every time a file changes under the current directory
-    putStrLn $ "[Rib] Watching " <> toFilePath src
+    putStrLn $ "[Rib] Watching " <> toFilePath src <> " for changes"
     void $ watchTree mgr (toFilePath src) (const True) $ \_ -> do
       runShake False
         `catch` \(e :: SomeException) -> putStrLn $ show e

--- a/src/Rib/Parser/MMark.hs
+++ b/src/Rib/Parser/MMark.hs
@@ -43,8 +43,8 @@ parsePure k s = case MMark.parse k s of
   Left e -> Left $ toText $ M.errorBundlePretty e
   Right doc -> Right $ MMark.useExtensions exts $ useTocExt doc
 
-parseIO :: MonadIO m => Path b File -> m (Either Text MMark)
-parseIO f = parsePure (toFilePath f) <$> readFileText (toFilePath f)
+parseIO :: MonadIO m => Path Rel File -> Text -> m (Either Text MMark)
+parseIO k s = pure $ parsePure (toFilePath k) s
 
 -- | Get the first image in the document if one exists
 getFirstImg :: MMark -> Maybe URI

--- a/src/Rib/Parser/Pandoc.hs
+++ b/src/Rib/Parser/Pandoc.hs
@@ -51,9 +51,8 @@ parsePure fmt s =
     runPure'
     $ readPandocFormat fmt readerSettings s
 
-parseIO :: MonadIO m => PandocFormat -> Path b File -> m (Either Text Pandoc)
-parseIO fmt f = fmap (first show) $ runExceptT $ do
-  content <- readFileText (toFilePath f)
+parseIO :: MonadIO m => PandocFormat -> Path Rel File -> Text -> m (Either Text Pandoc)
+parseIO fmt _k content = fmap (first show) $ runExceptT $ do
   v' <- runIO' $ readPandocFormat fmt readerSettings content
   liftIO $ walkM includeSources v'
   where

--- a/src/Rib/Shake.hs
+++ b/src/Rib/Shake.hs
@@ -101,12 +101,12 @@ buildHtml f = writeFileCached f . toString . Lucid.renderText
 -- Also, always writes under ribOutputDir
 writeFileCached :: Path Rel File -> String -> Action ()
 writeFileCached k s = do
-  let cacheClosure = (toFilePath k, s)
-      cacheKey = ("writeFileCached" :: Text, toFilePath k)
+  f <- fmap (toFilePath . (</> k)) ribOutputDir
+  let cacheClosure = (f, s)
+      cacheKey = ("writeFileCached" :: Text, f)
   cacheActionWith cacheKey cacheClosure $ do
-    output <- ribOutputDir
-    writeFile' (toFilePath $ output </> k) $! s
-    putInfo $ "[Rib] Wrote " <> toFilePath k
+    writeFile' f $! s
+    putInfo $ "W " <> f
 
 -- | Like `getDirectoryFiles` but works with `Path`
 getDirectoryFiles' :: Path b Dir -> [Path Rel File] -> Action [Path Rel File]

--- a/src/Rib/Shake.hs
+++ b/src/Rib/Shake.hs
@@ -19,8 +19,6 @@ module Rib.Shake
   )
 where
 
-import Data.Binary
-import Data.UUID (UUID)
 import Development.Shake
 import Development.Shake.Forward
 import Lucid (Html)
@@ -32,8 +30,7 @@ import Rib.Source
 data RibSettings
   = RibSettings
       { _ribSettings_inputDir :: Path Rel Dir,
-        _ribSettings_outputDir :: Path Rel Dir,
-        _ribSettings_processUUID :: UUID
+        _ribSettings_outputDir :: Path Rel Dir
       }
   deriving (Typeable)
 

--- a/src/Rib/Shake.hs
+++ b/src/Rib/Shake.hs
@@ -99,7 +99,10 @@ cacheActionWithFileContent f content act = do
   -- process. On the good side, within a single session (which is the typical
   -- run use case, at least for the author, esp. with ghcid) cache is observed.
   uuid <- _ribSettings_processUUID <$> ribSettings
-  cacheActionWith (toFilePath f) (show uuid <> content) act
+  let key = toFilePath f
+      -- NOTE: key must be part of the cache value to avoid an odd caching bug.
+      val = (uuid, key, content)
+  cacheActionWith key val act
 
 -- | Build a single HTML file with the given value
 buildHtml :: Path Rel File -> Html () -> Action ()

--- a/src/Rib/Shake.hs
+++ b/src/Rib/Shake.hs
@@ -96,8 +96,8 @@ cacheActionWithFileContent ::
   Action a
 cacheActionWithFileContent f content act = do
   -- FIXME: This does not preserve cache across multiple runs of the Haskell
-  -- process. On the good side, within a single ghcid session (which is the
-  -- typical run use case, at least for the author) cache is observed.
+  -- process. On the good side, within a single session (which is the typical
+  -- run use case, at least for the author, esp. with ghcid) cache is observed.
   uuid <- _ribSettings_processUUID <$> ribSettings
   cacheActionWith (toFilePath f) (show uuid <> content) act
 

--- a/src/Rib/Shake.hs
+++ b/src/Rib/Shake.hs
@@ -108,11 +108,9 @@ buildHtml f html = do
   writeHtml (output </> f) html
   putInfo $ "[Rib] Wrote " <> toFilePath (output </> f)
   where
-    writeHtml :: MonadIO m => Path b File -> Html () -> m ()
+    writeHtml :: Path b File -> Html () -> Action ()
     writeHtml p htmlVal = do
-      -- TODO: Is there a way to make Shake automatically do this for us?
-      createDirIfMissing True $ parent p
-      writeFileLText (toFilePath p) $! Lucid.renderText htmlVal
+      writeFile' (toFilePath p) $! toString $ Lucid.renderText htmlVal
 
 -- | Like `getDirectoryFiles` but works with `Path`
 getDirectoryFiles' :: Path b Dir -> [Path Rel File] -> Action [Path Rel File]

--- a/src/Rib/Source.hs
+++ b/src/Rib/Source.hs
@@ -50,12 +50,12 @@ sourceUrl doc = toText $ toFilePath ([absdir|/|] </> (sourcePath doc)) -<.> ".ht
 
 -- | A function that parses a source representation out of the given file
 type SourceReader repr =
-  forall m b. MonadIO m => Path b File -> m (Either Text repr)
+  forall m. MonadIO m => Path Rel File -> Text -> m (Either Text repr)
 
 readSource ::
   MonadIO m =>
   SourceReader repr ->
   Path Rel File ->
-  Path b File ->
+  Text ->
   m (Either Text (Source repr))
-readSource r k f = fmap (Source k) <$> r f
+readSource r k f = fmap (Source k) <$> r k f


### PR DESCRIPTION
After adding logging I caught a bug wherein even if one source is changed, shake rebuilds all HTML. This should be fixed. 