### PR TITLE
Make SourceReader a Shake Action

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ main = Rib.run [reldir|a|] [reldir|b|] generateSite
       -- - Function that will parse the file (here we use mmark)
       -- - Function that will generate the HTML (see below)
       srcs <-
-        Rib.buildHtmlMulti [[relfile|*.md|]] M.parseIO $
+        Rib.buildHtmlMulti [[relfile|*.md|]] M.parse $
           renderPage . Page_Single
       -- Build an index.html linking to the aforementioned files.
       Rib.buildHtml [relfile|index.html|] $

--- a/src/Rib/Parser/MMark.hs
+++ b/src/Rib/Parser/MMark.hs
@@ -10,8 +10,8 @@
 
 module Rib.Parser.MMark
   ( -- * Parsing
+    parse,
     parsePure,
-    parseIO,
 
     -- * Rendering
     render,
@@ -41,13 +41,20 @@ import Text.URI (URI)
 render :: MMark -> Html ()
 render = MMark.render
 
-parsePure :: FilePath -> Text -> Either Text MMark
+-- | Pure version of `parse`
+parsePure ::
+  -- | Filepath corresponding to the text to be parsed (used in parse errors)
+  FilePath ->
+  -- | Text to be parsed
+  Text ->
+  Either Text MMark
 parsePure k s = case MMark.parse k s of
   Left e -> Left $ toText $ M.errorBundlePretty e
   Right doc -> Right $ MMark.useExtensions exts $ useTocExt doc
 
-parseIO :: SourceReader MMark
-parseIO (toFilePath -> f) = do
+-- | `SourceReader` for parsing Markdown using mmark
+parse :: SourceReader MMark
+parse (toFilePath -> f) = do
   s <- toText <$> readFile' f
   pure $ parsePure f s
 

--- a/src/Rib/Parser/MMark.hs
+++ b/src/Rib/Parser/MMark.hs
@@ -26,6 +26,7 @@ module Rib.Parser.MMark
 where
 
 import Control.Foldl (Fold (..))
+import Development.Shake (readFile')
 import Lucid (Html)
 import Path
 import Rib.Source (SourceReader)
@@ -47,7 +48,7 @@ parsePure k s = case MMark.parse k s of
 
 parseIO :: SourceReader MMark
 parseIO (toFilePath -> f) = do
-  s <- readFileText f
+  s <- toText <$> readFile' f
   pure $ parsePure f s
 
 -- | Get the first image in the document if one exists

--- a/src/Rib/Parser/Pandoc.hs
+++ b/src/Rib/Parser/Pandoc.hs
@@ -10,8 +10,8 @@
 module Rib.Parser.Pandoc
   ( -- * Parsing
     PandocFormat (..),
+    parse,
     parsePure,
-    parseIO,
 
     -- * Rendering
     render,
@@ -49,14 +49,19 @@ readPandocFormat = \case
   PandocFormat_Markdown -> readMarkdown
   PandocFormat_RST -> readRST
 
+-- | Pure version of `parse`
 parsePure :: PandocFormat -> Text -> Either Text Pandoc
 parsePure fmt s =
   first show $ runExcept $ do
     runPure'
     $ readPandocFormat fmt readerSettings s
 
-parseIO :: PandocFormat -> SourceReader Pandoc
-parseIO fmt (toFilePath -> f) = do
+-- | `SourceReader` for parsing a lightweight markup language using Pandoc
+parse ::
+  -- | The markup format to use when parsing the source. Eg: `PandocFormat_Markdown`
+  PandocFormat ->
+  SourceReader Pandoc
+parse fmt (toFilePath -> f) = do
   content <- toText <$> readFile' f
   fmap (first show) $ runExceptT $ do
     v' <- runIO' $ readPandocFormat fmt readerSettings content

--- a/src/Rib/Shake.hs
+++ b/src/Rib/Shake.hs
@@ -12,6 +12,7 @@ module Rib.Shake
     buildStaticFiles,
     buildHtmlMulti,
     buildHtml,
+    readSource,
 
     -- * Misc
     RibSettings (..),
@@ -62,6 +63,22 @@ buildStaticFiles staticFilePatterns = do
     copyFileChanged' (toFilePath -> old) (toFilePath -> new) =
       copyFileChanged old new
 
+-- | Read and parse an individual source file from the source directory
+readSource ::
+  SourceReader repr ->
+  Path Rel File ->
+  Action (Either Text (Source repr))
+readSource r k = do
+  input <- ribInputDir
+  let f = input </> k
+  -- NOTE: We don't really use cacheActionWith prior to parsing content,
+  -- because the parsed representation (`repr`) may not always have instances
+  -- for Typeable/Binary/Generic (for example, MMark does not expose its
+  -- structure.). Consequently we are forced to cache merely the HTML writing
+  -- stage (see buildHtml').
+  need [toFilePath f]
+  fmap (Source k) <$> r f
+
 -- | Convert the given pattern of source files into their HTML.
 buildHtmlMulti ::
   -- | Source file patterns
@@ -75,15 +92,8 @@ buildHtmlMulti ::
 buildHtmlMulti pats parser r = do
   input <- ribInputDir
   fs <- getDirectoryFiles' input pats
-  forP fs $ \k -> do
-    let f = input </> k
-    -- NOTE: We don't really use cacheActionWith prior to parsing content,
-    -- because the parsed representation (`repr`) may not always have instances
-    -- for Typeable/Binary/Generic (for example, MMark does not expose its
-    -- structure.). Consequently we are forced to cache merely the HTML writing
-    -- stage (see buildHtml').
-    need [toFilePath f]
-    readSource parser k f >>= \case
+  forP fs $ \k ->
+    readSource parser k >>= \case
       Left e ->
         fail $ "Error parsing source " <> toFilePath k <> ": " <> show e
       Right src -> do

--- a/src/Rib/Source.hs
+++ b/src/Rib/Source.hs
@@ -9,9 +9,8 @@
 
 module Rib.Source
   ( -- * Source type
-    Source,
+    Source (..),
     SourceReader,
-    readSource,
 
     -- * Source properties
     sourcePath,
@@ -51,10 +50,3 @@ sourceUrl doc = toText $ toFilePath ([absdir|/|] </> (sourcePath doc)) -<.> ".ht
 
 -- | A function that parses a source representation out of the given file
 type SourceReader repr = forall b. Path b File -> Action (Either Text repr)
-
-readSource ::
-  SourceReader repr ->
-  Path Rel File ->
-  Path b File ->
-  Action (Either Text (Source repr))
-readSource r k f = fmap (Source k) <$> r f

--- a/src/Rib/Source.hs
+++ b/src/Rib/Source.hs
@@ -20,6 +20,7 @@ module Rib.Source
   )
 where
 
+import Development.Shake (Action)
 import Development.Shake.FilePath ((-<.>))
 import Path hiding ((-<.>))
 
@@ -49,13 +50,11 @@ sourceUrl :: Source repr -> Text
 sourceUrl doc = toText $ toFilePath ([absdir|/|] </> (sourcePath doc)) -<.> ".html"
 
 -- | A function that parses a source representation out of the given file
-type SourceReader repr =
-  forall m b. MonadIO m => Path b File -> m (Either Text repr)
+type SourceReader repr = forall b. Path b File -> Action (Either Text repr)
 
 readSource ::
-  MonadIO m =>
   SourceReader repr ->
   Path Rel File ->
   Path b File ->
-  m (Either Text (Source repr))
+  Action (Either Text (Source repr))
 readSource r k f = fmap (Source k) <$> r f


### PR DESCRIPTION
This will allow us to do Shake-y things in our readers. For example,
parsing our Dhall files may require [`need`](https://hackage.haskell.org/package/shake-0.18.4/docs/Development-Shake.html#v:need)'ing its dependent .dhall
files, doing which ensures that when those files change rib will
re-generate our site accordingly.

Code example:

```haskell
parse :: FromDhall a => Path b File -> Action (Either Text a)
parse (toFilePath -> f) = do
  inputDir <- ribInputDir
  let dhallDeps =
        [ [relfile|Entry.dhall|],
          [relfile|Metric.dhall|]
        ]
  need $ fmap (toFilePath . (inputDir </>)) dhallDeps
  s <- toText <$> readFile' f
  e <-
    liftIO $ withCurrentDirectory (toFilePath inputDir) $
      input auto s
  pure $ Right e

```