### PR TITLE
buildHtml* API changes

### DIFF
--- a/src/Rib/Shake.hs
+++ b/src/Rib/Shake.hs
@@ -13,6 +13,7 @@ module Rib.Shake
     buildStaticFiles,
     buildHtmlMulti,
     buildHtml,
+    buildHtml',
     writeHtml,
 
     -- * Misc
@@ -43,9 +44,15 @@ ribSettings = getShakeExtra >>= \case
   Just v -> pure v
   Nothing -> fail "RibSettings not initialized"
 
+-- | Input directory containing source files
+--
+-- This is same as the first argument to `Rib.App.run`
 ribInputDir :: Action (Path Rel Dir)
 ribInputDir = _ribSettings_inputDir <$> ribSettings
 
+-- Output directory containing generated files
+--
+-- This is same as the second argument to `Rib.App.run`
 ribOutputDir :: Action (Path Rel Dir)
 ribOutputDir = do
   output <- _ribSettings_outputDir <$> ribSettings
@@ -64,9 +71,11 @@ buildStaticFiles staticFilePatterns = do
     copyFileChanged' (toFilePath -> old) (toFilePath -> new) =
       copyFileChanged old new
 
--- | Read and parse an individual source file from the source directory
+-- | Read and parse an individual source file
 readSource ::
+  -- | How to parse the source
   SourceReader repr ->
+  -- | Path to the source file relative to `ribInputDir`
   Path Rel File ->
   Action (Source repr)
 readSource sourceReader k = do
@@ -98,15 +107,26 @@ buildHtmlMulti pats parser r = do
   fs <- getDirectoryFiles' input pats
   forP fs $ \k -> buildHtml k parser r
 
--- | Like buildHtmlMulti but operates on a single file.
+-- | Like `buildHtmlMulti` but operate on a single file.
 buildHtml ::
   Path Rel File ->
   SourceReader repr ->
   (Source repr -> Html ()) ->
   Action (Source repr)
 buildHtml k parser r = do
-  src <- readSource parser k
   outfile <- liftIO $ replaceExtension ".html" k
+  buildHtml' outfile k parser r
+
+-- | Like `buildHtml` but explicitly takes the output HTML path
+buildHtml' ::
+  -- | Path to the HTML file, relative to `ribOutputDir`
+  Path Rel File ->
+  Path Rel File ->
+  SourceReader repr ->
+  (Source repr -> Html ()) ->
+  Action (Source repr)
+buildHtml' outfile k parser r = do
+  src <- readSource parser k
   writeHtml outfile $ r src
   pure src
 

--- a/src/Rib/Shake.hs
+++ b/src/Rib/Shake.hs
@@ -13,7 +13,6 @@ module Rib.Shake
     buildStaticFiles,
     buildHtmlMulti,
     buildHtml,
-    buildHtml',
     writeHtml,
 
     -- * Misc
@@ -105,27 +104,21 @@ buildHtmlMulti ::
 buildHtmlMulti pats parser r = do
   input <- ribInputDir
   fs <- getDirectoryFiles' input pats
-  forP fs $ \k -> buildHtml k parser r
+  forP fs $ \k -> do
+    outfile <- liftIO $ replaceExtension ".html" k
+    buildHtml outfile k parser r
 
 -- | Like `buildHtmlMulti` but operate on a single file.
+--
+-- Also explicitly takes the output file path.
 buildHtml ::
-  Path Rel File ->
-  SourceReader repr ->
-  (Source repr -> Html ()) ->
-  Action (Source repr)
-buildHtml k parser r = do
-  outfile <- liftIO $ replaceExtension ".html" k
-  buildHtml' outfile k parser r
-
--- | Like `buildHtml` but explicitly takes the output HTML path
-buildHtml' ::
   -- | Path to the HTML file, relative to `ribOutputDir`
   Path Rel File ->
   Path Rel File ->
   SourceReader repr ->
   (Source repr -> Html ()) ->
   Action (Source repr)
-buildHtml' outfile k parser r = do
+buildHtml outfile k parser r = do
   src <- readSource parser k
   writeHtml outfile $ r src
   pure src


### PR DESCRIPTION
- Add outfile argument to buildHtml*
- Make parser the first argument in buildHtml*
- Add `buildHtml_` that discards its results

Example:

```haskell
  Rib.buildHtml_
    Tidbit.parse
    [relfile|tidbits.html|]
    [relfile|tidbits.dhall|]
    $ r . Page_Tidbits
  posts <-
    Rib.buildHtmlMulti
      MMark.parse
      [[relfile|*.md|]]
      $ r . Page_Individual
  Rib.buildHtml_
    MMark.parse
    [relfile|index.html|]
    [relfile|fragments/index.md|]
    $ r . Page_Index posts
```

*