### PR TITLE
sourceUrl: strip index.html

### DIFF
--- a/src/Rib/Shake.hs
+++ b/src/Rib/Shake.hs
@@ -122,8 +122,7 @@ buildHtml ::
   (Source repr -> Html ()) ->
   Action (Source repr)
 buildHtml parser outfile k r = do
-  let relUrl = toText $ toFilePath ([absdir|/|] </> outfile)
-  src <- Source k relUrl <$> readSource parser k
+  src <- Source k outfile <$> readSource parser k
   writeHtml outfile $ r src
   pure src
 

--- a/src/Rib/Source.hs
+++ b/src/Rib/Source.hs
@@ -27,10 +27,10 @@ import Relude
 -- | A source file on disk
 data Source repr
   = Source
-      { -- | Path to the source; relative to the source directory.
+      { -- | Path to the source; relative to `ribInputDir`
         _source_path :: Path Rel File,
-        -- | Relative URL (begins with `/`) to the generated HTML file
-        _source_url :: Text,
+        -- | Path to the generated HTML file; relative to `ribOutputDir`
+        _source_builtPath :: Path Rel File,
         -- | Parsed representation of the source.
         _source_val :: repr
       }
@@ -39,9 +39,11 @@ data Source repr
 sourcePath :: Source repr -> Path Rel File
 sourcePath = _source_path
 
+-- | Relative URL to the generated source HTML.
 sourceUrl :: Source repr -> Text
-sourceUrl = stripIndexHtml . _source_url
+sourceUrl = stripIndexHtml . relPathToUrl . _source_builtPath
   where
+    relPathToUrl = toText . toFilePath . ([absdir|/|] </>)
     stripIndexHtml s =
       if T.isSuffixOf "index.html" s
         then T.dropEnd (T.length $ "index.html") s

--- a/src/Rib/Source.hs
+++ b/src/Rib/Source.hs
@@ -19,6 +19,7 @@ module Rib.Source
   )
 where
 
+import qualified Data.Text as T
 import Development.Shake (Action)
 import Path
 import Relude
@@ -39,7 +40,12 @@ sourcePath :: Source repr -> Path Rel File
 sourcePath = _source_path
 
 sourceUrl :: Source repr -> Text
-sourceUrl = _source_url
+sourceUrl = stripIndexHtml . _source_url
+  where
+    stripIndexHtml s =
+      if T.isSuffixOf "index.html" s
+        then T.dropEnd (T.length $ "index.html") s
+        else s
 
 sourceVal :: Source repr -> repr
 sourceVal = _source_val


### PR DESCRIPTION
Make `Rib.sourceUrl` return `/a/b/` instead of `/a/b/index.html` as typical URLs favour the former over the later.
