### PR TITLE
Ability to customize the output filepath

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - API changes:
   - Introduced `forEvery` to run a Shake action over a pattern of files when they change.
   - Removed `buildHtmlMulti` (use `forEvery` with `buildHtml` instead)
+  - Exposed `Rib.Shake.writeFileCached`
 
 ## 0.6.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@
 - MMark, extensions removed:
   - `ghcSyntaxHighlighter`: we already have `skylighting` (which supports more parsers than Haskell)
   - `obfuscateEmail`: requires JS, which is not documented.
+- API changes:
+  - Introduced `forEvery` to run a Shake action over a pattern of files when they change.
+  - Removed `buildHtmlMulti` (use `forEvery` with `buildHtml` instead)
 
 ## 0.6.0.0
 

--- a/src/Rib/Shake.hs
+++ b/src/Rib/Shake.hs
@@ -138,7 +138,7 @@ buildHtml ::
 buildHtml k parser outfileFn r = do
   v <- readSource parser k
   outfile <- outfileFn k v
-  src <- Source k outfile <$> readSource parser k
+  let src = Source k outfile v
   writeHtml outfile $ r src
   pure src
 


### PR DESCRIPTION
**Background**: 
I'm writing an IRC log viewer using rib. And hit the abstracation ceiling of `Source`. Specifically I want to determine the output file name from the parsed structure (which contains the channel name).

It is basically impossible to customize `buildHtml` locally, because the `Source` constructor is not exported. Definitely a design smell that needs to be simplified, in the same manner as how I got rid of type classes.

**Initial API change**:
- Add a new parameter to `buildHtml` and `buildHtmlMulti` that takes a function which computes the output filepath based on two parameters: the input filepath and the parsed value.
- Provide a default implementation for this function, that ignores the parsed value and returns a outfile by replacing the extension with ".html" (current behaviour).

**Problems with the initial API**
- Complicates those two functions which now take yet another argument (4 arguments in total). 

**Tasks**
- [ ] Think of a better API 
- [ ] Implement the `Slug` type of #82