### PR TITLE
Replace `Source` with `Target src`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,9 @@
   - `ghcSyntaxHighlighter`: we already have `skylighting` (which supports more parsers than Haskell)
   - `obfuscateEmail`: requires JS, which is not documented.
 - API changes:
+  - Removed `buildHtmlMulti`, `buildHtml` and `Source` type.
+  - Introduced `Target` type, and `loadTarget`/`writeTarget` functions.
   - Introduced `forEvery` to run a Shake action over a pattern of files when they change.
-  - Removed `buildHtmlMulti` (use `forEvery` with `buildHtml` instead)
   - Exposed `Rib.Shake.writeFileCached`
 - Bug fixes
   - #95: Fix Shake error `resource busy (file is locked)`

--- a/rib.cabal
+++ b/rib.cabal
@@ -26,6 +26,7 @@ library
         Rib
         Rib.App
         Rib.Source
+        Rib.Target
         Rib.Parser.MMark
         Rib.Parser.Pandoc
         Rib.Shake

--- a/src/Rib.hs
+++ b/src/Rib.hs
@@ -2,6 +2,7 @@
 module Rib
   ( module Rib.App,
     module Rib.Shake,
+    module Rib.Target,
     Source,
     SourceReader,
     sourcePath,
@@ -14,6 +15,7 @@ where
 
 import Rib.App
 import Rib.Source
+import Rib.Target
 import Rib.Parser.MMark (MMark)
 import Rib.Parser.Pandoc (Pandoc)
 import Rib.Shake

--- a/src/Rib.hs
+++ b/src/Rib.hs
@@ -3,11 +3,7 @@ module Rib
   ( module Rib.App,
     module Rib.Shake,
     module Rib.Target,
-    Source,
     SourceReader,
-    sourcePath,
-    sourceVal,
-    sourceUrl,
     MMark,
     Pandoc,
   )

--- a/src/Rib/Shake.hs
+++ b/src/Rib/Shake.hs
@@ -18,6 +18,7 @@ module Rib.Shake
 
     -- * Writing only
     writeHtml,
+    writeTarget,
     writeFileCached,
 
     -- * Misc
@@ -36,6 +37,7 @@ import Path
 import Path.IO
 import Relude
 import Rib.Source
+import Rib.Target
 
 -- | RibSettings is initialized with the values passed to `Rib.App.run`
 data RibSettings
@@ -142,6 +144,10 @@ buildHtml' k parser outfileFn r = do
   let src = Source k outfile v
   writeHtml outfile $ r src
   pure src
+
+-- | Write the target file
+writeTarget :: Target a -> (Target a -> Html ()) -> Action ()
+writeTarget t r = writeHtml (targetPath t) (r t)
 
 -- | Write a single HTML file with the given HTML value
 --

--- a/src/Rib/Shake.hs
+++ b/src/Rib/Shake.hs
@@ -141,7 +141,7 @@ buildHtml' ::
 buildHtml' k parser outfileFn r = do
   v <- readSource parser k
   outfile <- outfileFn v
-  let t = Target outfile k v
+  let t = mkTargetWithSource k outfile v
   writeTarget t r
   pure t
 

--- a/src/Rib/Source.hs
+++ b/src/Rib/Source.hs
@@ -6,50 +6,11 @@
 {-# LANGUAGE Rank2Types #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
-module Rib.Source
-  ( -- * Source type
-    Source (..),
-    SourceReader,
+module Rib.Source where
 
-    -- * Source properties
-    sourcePath,
-    sourceUrl,
-    sourceVal,
-  )
-where
-
-import qualified Data.Text as T
 import Development.Shake (Action)
 import Path
 import Relude
-
--- | A source file on disk
-data Source repr
-  = Source
-      { _source_path :: Path Rel File,
-        -- | Path to the generated HTML file (relative to `Rib.Shake.ribOutputDir`)
-        _source_builtPath :: Path Rel File,
-        _source_val :: repr
-      }
-  deriving (Generic, Functor, Show)
-
--- | Path to the source file (relative to `Rib.Shake.ribInputDir`)
-sourcePath :: Source repr -> Path Rel File
-sourcePath = _source_path
-
--- | Relative URL to the generated source HTML.
-sourceUrl :: Source repr -> Text
-sourceUrl = stripIndexHtml . relPathToUrl . _source_builtPath
-  where
-    relPathToUrl = toText . toFilePath . ([absdir|/|] </>)
-    stripIndexHtml s =
-      if T.isSuffixOf "index.html" s
-        then T.dropEnd (T.length $ "index.html") s
-        else s
-
--- | Parsed representation of the source.
-sourceVal :: Source repr -> repr
-sourceVal = _source_val
 
 -- | A function that parses a source representation out of the given file
 type SourceReader repr = forall b. Path b File -> Action (Either Text repr)

--- a/src/Rib/Target.hs
+++ b/src/Rib/Target.hs
@@ -1,0 +1,54 @@
+{-# LANGUAGE DeriveFunctor #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE Rank2Types #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Rib.Target
+  ( -- * Target type
+    Target (..),
+
+    -- * Target properties
+    targetPath,
+    targetUrl,
+    targetVal,
+  )
+where
+
+import qualified Data.Text as T
+import Path
+import Relude
+
+-- | A generated file on disk
+data Target a
+  = Target
+      { _target_path :: Path Rel File,
+        -- ^ Path to the generated HTML file (relative to `Rib.Shake.ribOutputDir`)
+        _target_val :: a
+      }
+  deriving (Generic, Functor, Show)
+
+-- | Path to the source file (relative to `Rib.Shake.ribInputDir`)
+targetPath :: Target repr -> Path Rel File
+targetPath = _target_path
+
+-- | Parsed representation of the source.
+targetVal :: Target repr -> repr
+targetVal = _target_val
+
+-- | Relative URL to the generated source HTML.
+targetUrl :: Target repr -> Text
+targetUrl = urlForPath . _target_path
+
+-- | Given a path to a HTML file, return its relative URL
+urlForPath :: Path Rel File -> Text
+urlForPath = stripIndexHtml . relPathToUrl
+  where
+    relPathToUrl = toText . toFilePath . ([absdir|/|] </>)
+    stripIndexHtml s =
+      if T.isSuffixOf "index.html" s
+        then T.dropEnd (T.length $ "index.html") s
+        else s
+

--- a/src/Rib/Target.hs
+++ b/src/Rib/Target.hs
@@ -14,6 +14,7 @@ module Rib.Target
     targetPath,
     targetUrl,
     targetVal,
+    targetSrc,
   )
 where
 
@@ -22,24 +23,28 @@ import Path
 import Relude
 
 -- | A generated file on disk
-data Target a
+data Target src a
   = Target
       { _target_path :: Path Rel File,
         -- ^ Path to the generated HTML file (relative to `Rib.Shake.ribOutputDir`)
+        _target_src :: src,
         _target_val :: a
       }
   deriving (Generic, Functor, Show)
 
 -- | Path to the source file (relative to `Rib.Shake.ribInputDir`)
-targetPath :: Target repr -> Path Rel File
+targetPath :: Target src a -> Path Rel File
 targetPath = _target_path
 
+targetSrc :: Target src a -> src 
+targetSrc = _target_src
+
 -- | Parsed representation of the source.
-targetVal :: Target repr -> repr
+targetVal :: Target src a -> a
 targetVal = _target_val
 
 -- | Relative URL to the generated source HTML.
-targetUrl :: Target repr -> Text
+targetUrl :: Target src a -> Text
 targetUrl = urlForPath . _target_path
 
 -- | Given a path to a HTML file, return its relative URL

--- a/src/Rib/Target.hs
+++ b/src/Rib/Target.hs
@@ -8,7 +8,9 @@
 
 module Rib.Target
   ( -- * Target type
-    Target (..),
+    Target,
+    mkTarget,
+    mkTargetWithSource,
 
     -- * Target properties
     targetPath,
@@ -25,18 +27,24 @@ import Relude
 -- | A generated file on disk
 data Target src a
   = Target
-      { _target_path :: Path Rel File,
-        -- ^ Path to the generated HTML file (relative to `Rib.Shake.ribOutputDir`)
-        _target_src :: src,
+      { _target_src :: src,
+        -- | Path to the generated HTML file (relative to `Rib.Shake.ribOutputDir`)
+        _target_path :: Path Rel File,
         _target_val :: a
       }
   deriving (Generic, Functor, Show)
+
+mkTarget :: Path Rel File -> a -> Target () a
+mkTarget = Target ()
+
+mkTargetWithSource :: src -> Path Rel File -> a -> Target src a
+mkTargetWithSource = Target
 
 -- | Path to the source file (relative to `Rib.Shake.ribInputDir`)
 targetPath :: Target src a -> Path Rel File
 targetPath = _target_path
 
-targetSrc :: Target src a -> src 
+targetSrc :: Target src a -> src
 targetSrc = _target_src
 
 -- | Parsed representation of the source.
@@ -56,4 +64,3 @@ urlForPath = stripIndexHtml . relPathToUrl
       if T.isSuffixOf "index.html" s
         then T.dropEnd (T.length $ "index.html") s
         else s
-


### PR DESCRIPTION
**Purpose**: To handle cases where generated pages do not always have a corresponding source file ([example](https://github.com/srid/zulip-archive)).

**Related**: #82