### PR TITLE
Drop cacheActionWith

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - Bug fixes
   - #95: Fix Shake error `resource busy (file is locked)`
   - #97: Fix Shake error `AsyncCancelled` when server thread crashes
+  - #96 & #108: Drop problematic use of Shake `cacheActionWith`
 
 ## 0.6.0.0
 

--- a/src/Rib/App.hs
+++ b/src/Rib/App.hs
@@ -114,7 +114,9 @@ runWith src dst buildAction app = do
       shakeForward (ribShakeOptions fullGen) buildAction
         -- Gracefully handle any exceptions when running Shake actions. We want
         -- Rib to keep running instead of crashing abruptly.
-        `catch` \(e :: SomeException) -> putStrLn $ "[Rib] Shake error: " <> show e
+        `catch` \(e :: ShakeException) ->
+          putStrLn $
+            "[Rib] Unhandled exception when building " <> shakeExceptionTarget e <> ": " <> show e
     ribShakeOptions fullGen =
       shakeOptions
         { shakeVerbosity = Verbose,


### PR DESCRIPTION
Fixes  #96 and fixes #108, both caused by `cacheActionWith`'s behaviour.