### PR TITLE
Fix incorrect substitution in `routeUrl`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
   - API exposes the CLI parser (`optparse-applicative`) for user-level composition
   - Add `Rib.Parser.Pandoc.getToC` returning rendered Table of contents for a Pandoc document
   - `Rib.Extra.CSS`: add `googleFonts` and `stylesheet`
+- Bug fixes:
+  - `routeUrl`: Fix incorrect substitution of "foo-index.html" with "foo-"
 
 ## 0.7.0.0
 

--- a/src/Rib/Route.hs
+++ b/src/Rib/Route.hs
@@ -52,7 +52,7 @@ routeUrl' :: IsRoute r => UrlType -> r a -> Text
 routeUrl' urlType = stripIndexHtml . flip path2Url urlType . either (error . toText . displayException) id . routeFile
   where
     stripIndexHtml s =
-      if T.isSuffixOf "index.html" s
+      if "/index.html" `T.isSuffixOf` s || s == "index.html"
         then T.dropEnd (T.length $ "index.html") s
         else s
 


### PR DESCRIPTION
For a route path `foo-index.html`, `routeUrl` incorrectly returned `/foo-`.