### PR TITLE
Make Lucid rendering functions polymorphic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,9 @@
   - Add `Rib.Parser.Pandoc.getToC` returning rendered Table of contents for a Pandoc document
   - `Rib.Extra.CSS`: add `googleFonts` and `stylesheet`
   - Add `Rib.Extra.OpenGraph` for Open Graph protocol
-- Bug fixes:
+- Bug fixes and misc changes:
   - `routeUrl`: Fix incorrect substitution of "foo-index.html" with "foo-"
+  - Lucid rendering functions (like `MMark.render`) are now polymorphic in their monad.
 
 ## 0.7.0.0
 

--- a/src/Rib/Extra/CSS.hs
+++ b/src/Rib/Extra/CSS.hs
@@ -29,12 +29,12 @@ mozillaKbdStyle = do
   whiteSpace nowrap
 
 -- | Include the specified Google Fonts
-googleFonts :: [Text] -> Html ()
+googleFonts :: Monad m => [Text] -> HtmlT m ()
 googleFonts fs =
   let fsEncoded = T.intercalate "|" $ T.replace " " "+" <$> fs
       fsUrl = "https://fonts.googleapis.com/css?family=" <> fsEncoded <> "&display=swap"
    in stylesheet fsUrl
 
 -- | Include the specified stylesheet URL
-stylesheet :: Text -> Html ()
+stylesheet :: Monad m => Text -> HtmlT m ()
 stylesheet x = link_ [rel_ "stylesheet", href_ x]

--- a/src/Rib/Parser/MMark.hs
+++ b/src/Rib/Parser/MMark.hs
@@ -32,7 +32,7 @@ where
 
 import Control.Foldl (Fold (..))
 import Development.Shake (Action, readFile')
-import Lucid (Html)
+import Lucid.Base (HtmlT (..))
 import Path
 import Relude
 import Rib.Shake (ribInputDir)
@@ -44,8 +44,11 @@ import qualified Text.Megaparsec as M
 import Text.URI (URI)
 
 -- | Render a MMark document as HTML
-render :: MMark -> Html ()
-render = MMark.render
+render :: Monad m => MMark -> HtmlT m ()
+render = liftHtml . MMark.render
+  where
+    liftHtml :: Monad m => HtmlT Identity () -> HtmlT m ()
+    liftHtml = HtmlT . pure . runIdentity . runHtmlT
 
 -- | Like `parsePure` but takes a custom list of MMark extensions
 parsePureWith ::


### PR DESCRIPTION
This allows calling these functions from arbitrary `HtmlT m a` monad possible without fanfare. Currently they only work with `Identity`.