### PR TITLE
Tweak OpenGraph Fields, Add OGType ADT

### DIFF
--- a/rib.cabal
+++ b/rib.cabal
@@ -70,6 +70,7 @@ library
         safe-exceptions,
         shake >= 0.18.5,
         text >=1.2.3 && <1.3,
+        time >= 1.9,
         wai >=3.2.2 && <3.3,
         wai-app-static >=3.1.6 && <3.2,
         warp

--- a/src/Rib/Extra/OpenGraph.hs
+++ b/src/Rib/Extra/OpenGraph.hs
@@ -1,13 +1,18 @@
 {-# LANGUAGE GADTs #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
 
 -- | Meta tags for The Open Graph protocol: https://ogp.me/
 module Rib.Extra.OpenGraph
   ( OpenGraph (..),
+    OGType(..),
+    Article(..),
   )
 where
 
+import Data.Time (UTCTime)
+import Data.Time.Format.ISO8601 (formatShow, iso8601Format)
 import Lucid
 import Lucid.Base (makeAttribute)
 import Relude
@@ -19,10 +24,11 @@ import qualified Text.URI as URI
 data OpenGraph
   = OpenGraph
       { _openGraph_title :: Text,
-        _openGraph_author :: Text,
+        _openGraph_url :: Maybe URI.URI,
+        _openGraph_author :: Maybe Text,
         _openGraph_description :: Maybe Text,
         _openGraph_siteName :: Text,
-        _openGraph_type :: Text, -- TODO: ADT (different types with their own properties)
+        _openGraph_type :: Maybe OGType,
         _openGraph_image :: Maybe URI.URI
       }
   deriving (Eq, Show)
@@ -30,20 +36,64 @@ data OpenGraph
 instance ToHtml OpenGraph where
   toHtmlRaw = toHtml
   toHtml OpenGraph {..} = do
-    meta' "author" _openGraph_author
+    meta' "author" `mapM_` _openGraph_author
     meta' "description" `mapM_` _openGraph_description
+    requireAbsolute "OGP URL" (\uri -> link_ [rel_ "canonical", href_ uri]) `mapM_` _openGraph_url
     metaOg "title" _openGraph_title
     metaOg "site_name" _openGraph_siteName
-    metaOg "type" _openGraph_type
-    whenJust _openGraph_image $ \uri -> do
-      if isJust (URI.uriScheme uri)
-        then metaOg "image" $ URI.render uri
-        else error $ "OGP image URL must be absolute. This URI is not: " <> URI.render uri
+    toHtml `mapM_` _openGraph_type
+    requireAbsolute "OGP image URL" (metaOg "image") `mapM_` _openGraph_image
     where
-      -- Open graph meta element
-      metaOg k v =
-        meta_
-          [ makeAttribute "property" $ "og:" <> k,
-            content_ v
-          ]
       meta' k v = meta_ [name_ k, content_ v]
+      requireAbsolute description f uri =
+        if isJust (URI.uriScheme uri)
+          then f $ URI.render uri
+          else error $ description <> " must be absolute. this URI is not: " <> URI.render uri
+
+-- TODO: Remaining ADT values & sub-fields
+data OGType
+  = OGType_Article Article
+  deriving (Eq, Show)
+
+instance ToHtml OGType where
+  toHtmlRaw = toHtml
+  toHtml = \case
+    OGType_Article article -> do
+      metaOg "type" "article"
+      toHtml article
+
+
+-- TODO: _article_profile :: [Profile]
+data Article
+  = Article
+    { _article_section :: Maybe Text
+    , _article_modifiedTime :: Maybe UTCTime
+    , _article_publishedTime :: Maybe UTCTime
+    , _article_expirationTime :: Maybe UTCTime
+    , _article_tag :: [Text]
+    }
+  deriving (Eq, Show)
+
+instance ToHtml Article where
+  toHtmlRaw = toHtml
+  toHtml Article {..} = do
+    metaOg "article:section" `mapM_` _article_section
+    metaOgTime "article:modified_time" `mapM_` _article_modifiedTime
+    metaOgTime "article:published_time" `mapM_` _article_publishedTime
+    metaOgTime "article:expiration_time" `mapM_` _article_expirationTime
+    metaOg "article:tag" `mapM_` _article_tag
+    where
+      metaOgTime k t =
+        metaOg k $ toText $ formatShow iso8601Format t
+
+
+
+-- UTILS
+
+-- Open graph meta element
+metaOg :: Applicative m => Text -> Text -> HtmlT m ()
+metaOg k v =
+  meta_
+    [ makeAttribute "property" $ "og:" <> k,
+      content_ v
+    ]


### PR DESCRIPTION
Add an `_openGraph_url` field to the OpenGraph type & make the
`_openGraph_author` field optional.

Change the `_openGraph_type` field from a Text value to an ADT. There is
currently only one value for the Article type, along with an `OGArticle`
type for the article sub-fields.