### PR TITLE
Use relative to PWD paths when printing

### DIFF
--- a/rib.cabal
+++ b/rib.cabal
@@ -54,7 +54,6 @@ library
         exceptions,
         foldl,
         fsnotify >=0.3.0 && <0.4,
-        filepath,
         lucid >=2.9.11 && <2.10,
         megaparsec >= 8.0,
         mmark >= 0.0.7.2,

--- a/rib.cabal
+++ b/rib.cabal
@@ -34,6 +34,7 @@ library
         Rib.Extra.OpenGraph
     other-modules:
         Rib.Server
+        Rib.Logging
     hs-source-dirs: src
     default-language: Haskell2010
     default-extensions: NoImplicitPrelude

--- a/src/Rib/Logging.hs
+++ b/src/Rib/Logging.hs
@@ -1,12 +1,16 @@
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
 -- | Logging utilities
 module Rib.Logging
   ( -- * Basic
     formatPath,
+    prettyPrintPathFile,
+    prettyPrintPathDir,
+    RibSettings (..),
   )
 where
 
@@ -14,6 +18,23 @@ import Control.Monad.Catch
 import Path
 import Path.IO
 import Relude
+
+-- | RibSettings is initialized with the values passed to `Rib.App.run`
+data RibSettings
+  = RibSettings
+      { _ribSettings_inputDir :: Path Abs Dir,
+        _ribSettings_outputDir :: Path Abs Dir,
+        _ribSettings_workingDir :: Path Abs Dir
+      }
+  deriving (Typeable)
+
+prettyPrintPathFile :: MonadThrow m => RibSettings -> Path b File -> m Text
+prettyPrintPathFile RibSettings {..} fp =
+  toText . toFilePath <$> makeRelative _ribSettings_workingDir fp
+
+prettyPrintPathDir :: MonadThrow m => RibSettings -> Path b Dir -> m Text
+prettyPrintPathDir RibSettings {..} fp =
+  toText . toFilePath <$> makeRelative _ribSettings_workingDir fp
 
 -- | Format a file path before printing it to the user
 --

--- a/src/Rib/Logging.hs
+++ b/src/Rib/Logging.hs
@@ -1,0 +1,26 @@
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+-- | Logging utilities
+module Rib.Logging
+  ( -- * Basic
+    formatPath,
+  )
+where
+
+import Control.Monad.Catch
+import Path
+import Path.IO
+import Relude
+
+-- | Format a file path before printing it to the user
+--
+-- Returns the relative path to the base directory.
+--
+-- TODO: If the path is under the given base directory, return it as relative
+-- to that base. Otherwise return the absolute path.
+formatPath :: MonadThrow m => Path Abs Dir -> Path b File -> m Text
+formatPath baseDir fp =
+  toText . toFilePath <$> makeRelative baseDir fp

--- a/src/Rib/Server.hs
+++ b/src/Rib/Server.hs
@@ -9,7 +9,9 @@ where
 
 import Network.Wai.Application.Static (defaultFileServerSettings, ssListing, staticApp)
 import qualified Network.Wai.Handler.Warp as Warp
+import Path
 import Relude
+import Rib.Logging
 import WaiAppStatic.Types (StaticSettings)
 
 -- | WAI Settings suited for serving statically generated websites.
@@ -25,16 +27,18 @@ staticSiteServerSettings root =
 --
 -- Binds the server to host 127.0.0.1.
 serve ::
+  RibSettings ->
   -- | Port number to bind to
   Int ->
   -- | Directory to serve.
-  FilePath ->
+  Path b Dir ->
   IO ()
-serve port path = do
-  putStrLn $ "[Rib] Serving " <> path <> " at http://" <> host <> ":" <> show port
+serve ribSettings port path = do
+  pathS <- prettyPrintPathDir ribSettings path
+  putStrLn $ "[Rib] Serving " <> toString pathS <> " at http://" <> host <> ":" <> show port
   Warp.runSettings settings app
   where
-    app = staticApp $ staticSiteServerSettings path
+    app = staticApp $ staticSiteServerSettings $ toFilePath path
     host = "127.0.0.1"
     settings =
       Warp.setHost (fromString host)

--- a/src/Rib/Server.hs
+++ b/src/Rib/Server.hs
@@ -27,6 +27,7 @@ staticSiteServerSettings root =
 --
 -- Binds the server to host 127.0.0.1.
 serve ::
+  Typeable b =>
   RibSettings ->
   -- | Port number to bind to
   Int ->

--- a/src/Rib/Shake.hs
+++ b/src/Rib/Shake.hs
@@ -39,19 +39,17 @@ ribSettings = getShakeExtra >>= \case
 --
 -- This is same as the first argument to `Rib.App.run`, but relative to the
 -- working directory.
-ribInputDir :: Action (Path Rel Dir)
-ribInputDir = do
-  RibSettings {..} <- ribSettings
-  liftIO $ makeRelative _ribSettings_workingDir _ribSettings_inputDir
+ribInputDir :: Action (Path Abs Dir)
+ribInputDir =
+  _ribSettings_inputDir <$> ribSettings
 
 -- Output directory containing generated files
 --
 -- This is same as the second argument to `Rib.App.run`, but relative to the
 -- working directory.
-ribOutputDir :: Action (Path Rel Dir)
+ribOutputDir :: Action (Path Abs Dir)
 ribOutputDir = do
-  RibSettings {..} <- ribSettings
-  outputDir <- liftIO $ makeRelative _ribSettings_workingDir _ribSettings_outputDir
+  outputDir <- _ribSettings_outputDir <$> ribSettings
   liftIO $ createDirIfMissing True outputDir
   return outputDir
 

--- a/src/Rib/Shake.hs
+++ b/src/Rib/Shake.hs
@@ -31,8 +31,8 @@ import Relude
 -- | RibSettings is initialized with the values passed to `Rib.App.run`
 data RibSettings
   = RibSettings
-      { _ribSettings_inputDir :: Path Abs Dir,
-        _ribSettings_outputDir :: Path Abs Dir
+      { _ribSettings_inputDir :: Path Rel Dir,
+        _ribSettings_outputDir :: Path Rel Dir
       }
   deriving (Typeable)
 
@@ -45,13 +45,13 @@ ribSettings = getShakeExtra >>= \case
 -- | Input directory containing source files
 --
 -- This is same as the first argument to `Rib.App.run`
-ribInputDir :: Action (Path Abs Dir)
+ribInputDir :: Action (Path Rel Dir)
 ribInputDir = _ribSettings_inputDir <$> ribSettings
 
 -- Output directory containing generated files
 --
 -- This is same as the second argument to `Rib.App.run`
-ribOutputDir :: Action (Path Abs Dir)
+ribOutputDir :: Action (Path Rel Dir)
 ribOutputDir = do
   output <- _ribSettings_outputDir <$> ribSettings
   liftIO $ createDirIfMissing True output

--- a/src/Rib/Shake.hs
+++ b/src/Rib/Shake.hs
@@ -17,7 +17,6 @@ module Rib.Shake
     writeFileCached,
 
     -- * Misc
-    RibSettings (..),
     ribInputDir,
     ribOutputDir,
     getDirectoryFiles',
@@ -28,15 +27,7 @@ import Development.Shake
 import Path
 import Path.IO
 import Relude
-
--- | RibSettings is initialized with the values passed to `Rib.App.run`
-data RibSettings
-  = RibSettings
-      { _ribSettings_inputDir :: Path Abs Dir,
-        _ribSettings_outputDir :: Path Abs Dir,
-        _ribSettings_workingDir :: Path Abs Dir
-      }
-  deriving (Typeable)
+import Rib.Logging
 
 -- | Get rib settings from a shake Action monad.
 ribSettings :: Action RibSettings


### PR DESCRIPTION
Fixes #132 

- [ ] See if `RibSettings` can retain using absolute paths, while only logging deals with relative paths. Maybe store the original PWD also in RibSettings? (The user may change the PWD in the intermi after all ...)
- [ ] Do not use relative path when printing if absolute paths were passed to `runWith`

![image](https://user-images.githubusercontent.com/3998/77688151-f88bf500-6f75-11ea-9bbd-b0ad969be951.png)
