### PR TITLE
Go back to relative paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,6 @@
   - `routeUrl`: Fix incorrect substitution of "foo-index.html" with "foo-"
   - Lucid rendering functions (like `MMark.render`) are now polymorphic in their monad.
   - #122: Fix Pandoc parser never returning metadata
-  - `run` and `runWith` now accept absolute paths (`Path b Dir`).
   - #127: Rib's HTTP server now binds to `127.0.0.1`.
   - default.nix: Takes `overrides` and `additional-packages` as extra arguments
   - #130: Prevent unnecessary re-running of Shake action by debouncing fsnotify events

--- a/src/Rib/Shake.hs
+++ b/src/Rib/Shake.hs
@@ -31,8 +31,8 @@ import Relude
 -- | RibSettings is initialized with the values passed to `Rib.App.run`
 data RibSettings
   = RibSettings
-      { _ribSettings_inputDir :: Path Abs Dir,
-        _ribSettings_outputDir :: Path Abs Dir
+      { _ribSettings_inputDir :: Path Rel Dir,
+        _ribSettings_outputDir :: Path Rel Dir
       }
   deriving (Typeable)
 
@@ -45,13 +45,13 @@ ribSettings = getShakeExtra >>= \case
 -- | Input directory containing source files
 --
 -- This is same as the first argument to `Rib.App.run`
-ribInputDir :: Action (Path Abs Dir)
+ribInputDir :: Action (Path Rel Dir)
 ribInputDir = _ribSettings_inputDir <$> ribSettings
 
 -- Output directory containing generated files
 --
 -- This is same as the second argument to `Rib.App.run`
-ribOutputDir :: Action (Path Abs Dir)
+ribOutputDir :: Action (Path Rel Dir)
 ribOutputDir = do
   output <- _ribSettings_outputDir <$> ribSettings
   liftIO $ createDirIfMissing True output


### PR DESCRIPTION
`runWith` now takes relative paths. 

The current working directory has some significance with rib, in that Shake will store its database `.shake` under it. By using relative directories, users are forced to think about what their current working directory is. Also, a "relative" path in rib has to be under the current working directory (so using "../" is not allowed by the `path` library).

This also fixes [this regression](https://github.com/srid/rib/commit/5a55ccf771fc1e0722b7954e9daca4ccb35d6625#r38075444) in a recent commit.

Fixes #132 (obviates it, as all paths are now relative)
