### PR TITLE
Allow directory listing in the HTTP server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
   - Lucid rendering functions (like `MMark.render`) are now polymorphic in their monad.
   - #122: Fix Pandoc parser never returning metadata
   - #127: Rib's HTTP server now binds to `127.0.0.1`.
+  - Allow directory listings in HTTP server
   - default.nix: Takes `overrides` and `additional-packages` as extra arguments
   - #130: Prevent unnecessary re-running of Shake action by debouncing fsnotify events
 

--- a/src/Rib/Server.hs
+++ b/src/Rib/Server.hs
@@ -7,19 +7,9 @@ module Rib.Server
   )
 where
 
-import Network.Wai.Application.Static (defaultFileServerSettings, ssListing, staticApp)
+import Network.Wai.Application.Static (defaultFileServerSettings, staticApp)
 import qualified Network.Wai.Handler.Warp as Warp
 import Relude
-import WaiAppStatic.Types (StaticSettings)
-
--- | WAI Settings suited for serving statically generated websites.
-staticSiteServerSettings :: FilePath -> StaticSettings
-staticSiteServerSettings root =
-  defaultSettings
-    { ssListing = Nothing -- Disable directory listings
-    }
-  where
-    defaultSettings = defaultFileServerSettings root
 
 -- | Run a HTTP server to serve a directory of static files
 --
@@ -34,7 +24,7 @@ serve port path = do
   putStrLn $ "[Rib] Serving " <> path <> " at http://" <> host <> ":" <> show port
   Warp.runSettings settings app
   where
-    app = staticApp $ staticSiteServerSettings path
+    app = staticApp $ defaultFileServerSettings path
     host = "127.0.0.1"
     settings =
       Warp.setHost (fromString host)


### PR DESCRIPTION
Rib's server is meant to be run internally anyway.

cf. https://github.com/srid/neuron/issues/29