### PR TITLE
Fix tutorial commands

### DIFF
--- a/guide/tutorial.md
+++ b/guide/tutorial.md
@@ -33,7 +33,7 @@ Clone the sample repository locally, install [Nix](https://nixos.org/nix/) (as
 described in its README) and run your site as follows:
 
 ```bash
-nix-shell --run 'ghcid -T ":main serve"'
+nix-shell --run 'ghcid -T ":main -wS"'
 ```
 
 Running this command gives you a local HTTP server at <http://127.0.0.1:8080>
@@ -58,7 +58,7 @@ installed.
 4. `Rib.App.run`: this parses the CLI arguments and runs the rib CLI "app" which
    can be run in one of a few modes --- generating static files, watching the
    `content/` directory for changes, starting HTTP server for the `dest/` directory.
-   The "serve" subcommand will run the Shake build action passed as argument on 
+   The "-wS" options will run the Shake build action passed as argument on 
    every file change and spin up a HTTP server.
    
 Run that command, and visit <http://127.0.0.1:8080> to view your site.


### PR DESCRIPTION
I reached this point in the [tutorial](https://rib.srid.ca/tutorial.html):
> Clone the sample repository locally, install [Nix](https://nixos.org/nix/) (as described in its README) and run your site as follows:
> ```bash
> nix-shell --run 'ghcid -T ":main serve"'
> ```

This no longer works:
```
Invalid argument `serve'

Usage: <interactive> [--rebuild-all] [-w|--watch] 
                     [(-s|--serve [HOST]:PORT) | -S] [--quiet] 
                     [--input-dir INPUTDIR] [--output-dir OUTPUTDIR]
  Generate a static site at OUTPUTDIR using input from INPUTDIR
*** Exception: ExitFailure 1
```

I saw that the `serve` command was updated in the changelog:
```diff
❯ git show c115fe39633924367b5c2709d98882d42714d5b5 CHANGELOG.md
commit c115fe39633924367b5c2709d98882d42714d5b5
Author: Sridhar Ratnakumar <srid@srid.ca>
Date:   Fri Apr 10 11:14:58 2020 -0400

    Add -S alias

diff --git a/CHANGELOG.md b/CHANGELOG.md
index 37246d0..99e3d45 100644
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
     - This also lifts the restriction with absolute paths
 - Misc changes
   - #145: CLI arguments have been revamped
+    - `serve` subcommand is replaced by the options `-wS`.
     - Added `--input-dir/--output-dir` to override these paths
     - Accept host string in addition to port number
     - Exposed `Rib.Shake.getCliConfig` to get full CLI configuration
```

I tried running with the new options mentioned: `nix-shell --run 'ghcid -T ":main -wS"'`
```
[Rib] Serving dest at http://127.0.0.1:8080
[Rib] Generating content (rebuildAll=True)
# content/static/README.md
# content/first-post.md
# content/second-post.md
[Rib] Watching content for changes
```

It worked. I pushed a documentation update so nobody else gets confused by this.